### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/ast_parser.py
+++ b/ast_parser.py
@@ -17,11 +17,28 @@ def print_colored(message, style="white"):
     else:
         print(message)
 
-def parse_file_to_ast(filepath, verbosity="normal"):
+import os
+
+def _is_path_within_root(filepath, root):
+    """Check if the given filepath is within the root directory."""
+    abs_root = os.path.abspath(root)
+    abs_path = os.path.abspath(filepath)
+    try:
+        common = os.path.commonpath([abs_root, abs_path])
+    except ValueError:
+        # On Windows, if drives differ, commonpath raises ValueError
+        return False
+    return common == abs_root
+
+def parse_file_to_ast(filepath, verbosity="normal", safe_root=None):
     """
     Parse the file at `filepath` into an AST.
     Returns a tuple: (filename, AST node, source code string)
     """
+    if safe_root is None:
+        safe_root = os.getcwd()
+    if not _is_path_within_root(filepath, safe_root):
+        raise Exception(f"Access to file '{filepath}' is not allowed (outside of root directory '{safe_root}').")
     try:
         with open(filepath, "r", encoding="utf-8") as f:
             source_code = f.read()

--- a/indexer.py
+++ b/indexer.py
@@ -121,7 +121,9 @@ def index_project(filepaths, py2_mode=False, skip_errors=False, verbosity="norma
                     )
 
                 # Parse AST from the temp file
-                filename, tree, source = parse_file_to_ast(temp_path, verbosity)
+                # Pass the original root directory as safe_root for validation
+                safe_root = os.getcwd()
+                filename, tree, source = parse_file_to_ast(temp_path, verbosity, safe_root=safe_root)
                 if not tree:
                     if skip_errors:
                         if verbosity != "quiet":


### PR DESCRIPTION
Potential fix for [https://github.com/anotherik/pickle_inspector/security/code-scanning/9](https://github.com/anotherik/pickle_inspector/security/code-scanning/9)

To fix the problem, we should ensure that any file path used in `open()` is validated to prevent path traversal and access to unintended files. The best general approach is to define a "safe root" directory (e.g., the current working directory or a user-specified project root), normalize the user-supplied path, and check that the resulting path is within the allowed root. This can be done using `os.path.abspath` and `os.path.commonpath` or by checking that the normalized path starts with the root directory.

Since the code in question is in `ast_parser.py`, and the file paths are passed in from `indexer.py`, which in turn gets them from `cli.py`, we should add a validation function in `ast_parser.py` to check that the file is within a safe root. The root can be passed as an argument to `parse_file_to_ast`, or, for minimal change, we can default to the current working directory. The validation should be performed before opening the file.

**Required changes:**
- In `ast_parser.py`, add a helper function to validate that `filepath` is within a safe root (default: current working directory).
- In `parse_file_to_ast`, before opening the file, normalize and check the path.
- If the path is not within the allowed root, raise an exception or return an error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
