### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/report.py
+++ b/report.py
@@ -217,6 +217,12 @@ def export_json_report(findings, output_file):
         }
         json_data["findings"].append(finding_data)
 
+    # Ensure output_file is within the reports directory
+    reports_dir_abs = os.path.abspath("reports")
+    output_file_abs = os.path.abspath(output_file)
+    if not output_file_abs.startswith(reports_dir_abs + os.sep):
+        raise Exception(f"Refusing to write outside reports directory: {output_file_abs}")
+
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(json_data, f, indent=2)
     print(f"[+] JSON report written to {output_file}")


### PR DESCRIPTION
Potential fix for [https://github.com/anotherik/pickle_inspector/security/code-scanning/10](https://github.com/anotherik/pickle_inspector/security/code-scanning/10)

To fix the problem, we should ensure that the file path used for writing the JSON report is always contained within the intended `reports` directory, regardless of user input. This can be achieved by normalizing the final path (using `os.path.abspath` or `os.path.realpath`) and verifying that it starts with the absolute path of the `reports` directory. If the check fails, the function should raise an exception or refuse to write the file. This check should be added to the `export_json_report` function in `report.py`, just before opening the file for writing. No changes are needed to the CLI or utils, as the fix is best placed at the point of file access.

**Required changes:**
- In `report.py`, in `export_json_report`, before the `open(output_file, ...)` call, normalize the path and check that it is within the `reports` directory.
- If the check fails, raise an exception or print an error and return.
- Add a helper function (if needed) to perform the check, or do it inline.
- No new imports are needed, as `os` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
